### PR TITLE
LIBSEARCH-13. Updated "loofah" gem to v2.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
     libv8 (3.16.14.19)
-    loofah (2.2.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)


### PR DESCRIPTION
Updated "loofah" gem to v2.2.1 to take care of a GitHub security
vulnerability warning.

Ran the following command:

```
> bundle update loofah
```

https://issues.umd.edu/browse/LIBSEARCH-13